### PR TITLE
Fixed input name from github-token to ghToken

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Potential Conflicts Checker
 description: Check if this Pull Request can be conflict after other Pull Requests merged
 inputs:
-  github-token:
+  ghToken:
     description: The GitHub token used to create an authenticated client.
 runs:
   using: docker


### PR DESCRIPTION
Fixed input name from `github-token` to the correct  `ghToken`.
This should prevent the following warning when running this action in a workflow:

```text
Unexpected input(s) 'ghToken', valid inputs are ['entryPoint', 'args', 'github-token']
```
